### PR TITLE
Flatten packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ func printDomainNames(username, privKeyPath string) error {
 		return err
 	}
 	fmt.Printf("Managed domains:\n")
-	for _, domain := range domains.Domains {
+	for _, domain := range domains {
 		fmt.Printf("★ %s\n", domain.Name)
 		fmt.Printf("\t%+v\n\n", domain)
 	}

--- a/README.md
+++ b/README.md
@@ -3,19 +3,49 @@ TransIP API
 Small library in Golang that implements:
 * DomainService/getDomainNames
 * DomainService/getInfo
+* DomainService/batchGetInfo
 * DomainService/setDnsEntries
 
 If you need other methods on the TransIP API be free to fork my
 code and I'll merge it with love. :)
 
 Why use this library instead of writing own:
-* 'Correctly' implementing __nonce because there's no uniqid in Golang;
+* 'Correctly' implementing \_\_nonce because there's no uniqid in Golang;
 * Correctly implementing signature, RSA Private key signing of cookie signature (unittests included);
 * Tokenized XML-parser to keep data structures free of clutter (stripping SOAP envelopes);
 
 Example code
 =======
-Get a list of domains and return all of their details
+Get info for a domain
+```go
+package main
+
+import (
+	"github.com/mpdroog/transip"
+	"github.com/mpdroog/transip/creds"
+	"fmt"
+)
+
+func printDomainInfo(username, privKeyPath string) {
+	creds := creds.Client{
+		Login:     username,
+		ReadWrite: false,
+	}
+	if err := creds.SetPrivateKeyFromPath(privKeyPath); err != nil {
+		return fmt.Errorf("could not load private key from path %s: %s",
+			privKeyPath, err)
+	}
+    	
+	domainService := transip.DomainService{creds}
+	domain, err := domainService.Domain("example.com")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("\t%+v\n\n", domain)
+}
+```
+
+Get a list of domain names and return all of their details
 ```go
 package main
 
@@ -26,32 +56,30 @@ import (
 )
 
 func printDomainNames(username, privKeyPath string) error {
-    creds := creds.Client{
-        Login:     username,
-        ReadWrite: false,
-    }
-    if err := creds.SetPrivateKeyFromPath(privKeyPath); err != nil {
-        return fmt.Errorf("could not load private key from path %s: %s",
-            privKeyPath, err)
-    }
+	creds := creds.Client{
+		Login:     username,
+		ReadWrite: false,
+	}
+	if err := creds.SetPrivateKeyFromPath(privKeyPath); err != nil {
+		return fmt.Errorf("could not load private key from path %s: %s",
+			privKeyPath, err)
+	}
     	
-    domainService := transip.DomainService{creds}
-	domains, err := domainService.DomainNames()
+	domainService := transip.DomainService{creds}
+	domainNames, err := domainService.DomainNames()
 	if err != nil {
 		return err
 	}
-
-	fmt.Printf("Managed domains:\n")
-	for _, domain := range domains.Item {
-		fmt.Printf("★ %s\n", domain)
-
-		info, err := domainService.Domain(domain)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("\t%+v\n\n", info)
+	domains, err := domainService.Domains(domainNames)
+	if err != nil {
+		return err
 	}
-	
+	fmt.Printf("Managed domains:\n")
+	for _, domain := range domains.Domains {
+		fmt.Printf("★ %s\n", domain.Name)
+		fmt.Printf("\t%+v\n\n", domain)
+	}
+
 	return nil
 }
 ```
@@ -63,27 +91,27 @@ package main
 import (
 	"github.com/mpdroog/transip"
 	"github.com/mpdroog/transip/creds"
-    "github.com/mpdroog/transip/soap"
+	"github.com/mpdroog/transip/soap"
 	"fmt"
 )
 
 func overWriteDnsEntries(username, privKeyPath, domain string) error {
-    creds := creds.Client{
-        Login:     username,
-        ReadWrite: false,
-    }
-    if err := creds.SetPrivateKeyFromPath(privKeyPath); err != nil {
-        return fmt.Errorf("could not load private key from path %s: %s",
-            privKeyPath, err)
-    }
-        
-    // 360 = 6min (TTL in seconds)
-    recordSet := []soap.DomainDNSentry{
-    	{Name: "@", Expire: 360, Type: "A", Content: "127.0.0.1"},
-    }
-    
-    domainService := transip.DomainService{creds}
-    err := domainService.SetDNSEntries(domain, recordSet)
-    return err
+	creds := creds.Client{
+		Login:     username,
+		ReadWrite: false,
+	}
+	if err := creds.SetPrivateKeyFromPath(privKeyPath); err != nil {
+		return fmt.Errorf("could not load private key from path %s: %s",
+	    		privKeyPath, err)
+	}
+
+	// 360 = 6min (TTL in seconds)
+	recordSet := []soap.DomainDNSentry{
+		{Name: "@", Expire: 360, Type: "A", Content: "127.0.0.1"},
+	}
+
+	domainService := transip.DomainService{creds}
+	err := domainService.SetDNSEntries(domain, recordSet)
+	return err
 }
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import (
 	"fmt"
 )
 
-func printDomainInfo(username, privKeyPath string) {
+func printDomainInfo(username, privKeyPath string) error {
 	creds := creds.Client{
 		Login:     username,
 		ReadWrite: false,
@@ -42,6 +42,7 @@ func printDomainInfo(username, privKeyPath string) {
 		return err
 	}
 	fmt.Printf("\t%+v\n\n", domain)
+    return nil
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ func printDomainNames(username, privKeyPath string) error {
 	if err != nil {
 		return err
 	}
-	domains, err := domainService.Domains(domainNames)
+	domains, err := domainService.Domains(domainNames.Item)
 	if err != nil {
 		return err
 	}

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ import (
 func overWriteDnsEntries(username, privKeyPath, domain string) error {
 	creds := creds.Client{
 		Login:     username,
-		ReadWrite: false,
+		ReadWrite: true,
 	}
 	if err := creds.SetPrivateKeyFromPath(privKeyPath); err != nil {
 		return fmt.Errorf("could not load private key from path %s: %s",

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Small library in Golang that implements:
 * DomainService/getInfo
 * DomainService/batchGetInfo
 * DomainService/setDnsEntries
+* DomainService/checkAvailability
 
 If you need other methods on the TransIP API be free to fork my
 code and I'll merge it with love. :)
@@ -110,5 +111,34 @@ func overWriteDnsEntries(username, privKeyPath, domain string) error {
 	domainService := transip.DomainService{creds}
 	err := domainService.SetDNSEntries(domain, recordSet)
 	return err
+}
+```
+
+Check availability of a domain
+```go
+package main
+
+import (
+	"github.com/mpdroog/transip"
+	"fmt"
+)
+
+func checkAvailability(username, privKeyPath, domain string) (string, error) {
+	creds := transip.Client{
+        Login:     username,
+        ReadWrite: false,
+    }
+    if err := creds.SetPrivateKeyFromPath(privKeyPath); err != nil {
+        return "", fmt.Errorf("could not load private key from path %s: %s",
+            privKeyPath, err)
+    }
+
+    domainService := transip.DomainService{creds}
+	res, err := domainService.CheckAvailability(domain)
+	if err != nil {
+		return "", err
+	}
+
+    return res, nil
 }
 ```

--- a/README.md
+++ b/README.md
@@ -22,12 +22,11 @@ package main
 
 import (
 	"github.com/mpdroog/transip"
-	"github.com/mpdroog/transip/creds"
 	"fmt"
 )
 
 func printDomainInfo(username, privKeyPath string) error {
-	creds := creds.Client{
+	creds := transip.Client{
 		Login:     username,
 		ReadWrite: false,
 	}
@@ -42,7 +41,7 @@ func printDomainInfo(username, privKeyPath string) error {
 		return err
 	}
 	fmt.Printf("\t%+v\n\n", domain)
-    return nil
+	return nil
 }
 ```
 
@@ -52,12 +51,11 @@ package main
 
 import (
 	"github.com/mpdroog/transip"
-	"github.com/mpdroog/transip/creds"
 	"fmt"
 )
 
 func printDomainNames(username, privKeyPath string) error {
-	creds := creds.Client{
+	creds := transip.Client{
 		Login:     username,
 		ReadWrite: false,
 	}
@@ -71,7 +69,7 @@ func printDomainNames(username, privKeyPath string) error {
 	if err != nil {
 		return err
 	}
-	domains, err := domainService.Domains(domainNames.Item)
+	domains, err := domainService.Domains(domainNames)
 	if err != nil {
 		return err
 	}
@@ -91,13 +89,11 @@ package main
 
 import (
 	"github.com/mpdroog/transip"
-	"github.com/mpdroog/transip/creds"
-	"github.com/mpdroog/transip/soap"
 	"fmt"
 )
 
 func overWriteDnsEntries(username, privKeyPath, domain string) error {
-	creds := creds.Client{
+	creds := transip.Client{
 		Login:     username,
 		ReadWrite: false,
 	}
@@ -107,7 +103,7 @@ func overWriteDnsEntries(username, privKeyPath, domain string) error {
 	}
 
 	// 360 = 6min (TTL in seconds)
-	recordSet := []soap.DomainDNSentry{
+	recordSet := []transip.DomainDNSentry{
 		{Name: "@", Expire: 360, Type: "A", Content: "127.0.0.1"},
 	}
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Small library in Golang that implements:
 * DomainService/getInfo
 * DomainService/batchGetInfo
 * DomainService/setDnsEntries
+* DomainService/batchCheckAvailability
 * DomainService/checkAvailability
 
 If you need other methods on the TransIP API be free to fork my
@@ -137,6 +138,35 @@ func checkAvailability(username, privKeyPath, domain string) (string, error) {
 	res, err := domainService.CheckAvailability(domain)
 	if err != nil {
 		return "", err
+	}
+
+    return res, nil
+}
+```
+
+Check availability of a batch of domains
+```go
+package main
+
+import (
+	"github.com/mpdroog/transip"
+	"fmt"
+)
+
+func checkAvailability(username, privKeyPath string, domains []string) ([]transip.DomainCheckResult, error) {
+	creds := transip.Client{
+        Login:     username,
+        ReadWrite: false,
+    }
+    if err := creds.SetPrivateKeyFromPath(privKeyPath); err != nil {
+        return nil, fmt.Errorf("could not load private key from path %s: %s",
+            privKeyPath, err)
+    }
+
+    domainService := transip.DomainService{creds}
+	res, err := domainService.BatchCheckAvailability(domains)
+	if err != nil {
+		return nil, err
 	}
 
     return res, nil

--- a/creds.go
+++ b/creds.go
@@ -1,4 +1,4 @@
-package creds
+package transip
 
 import (
 	"crypto/rsa"

--- a/decode.go
+++ b/decode.go
@@ -23,6 +23,10 @@ type DomainNames struct {
 	Item []string `xml:"item"`
 }
 
+type availability struct {
+	Item string `xml:"return"`
+}
+
 type Domains struct {
 	Domains []Domain `xml:"item"`
 }
@@ -83,6 +87,12 @@ func decode(rawbody []byte, out interface{}) error {
 
 		switch se := tok.(type) {
 		case xml.StartElement:
+			if se.Name.Local == "checkAvailabilityResponse" {
+				// Start readin'!
+				if e := dec.DecodeElement(out, &se); e != nil {
+					return e
+				}
+			}
 			if se.Name.Local == "return" {
 				// Start readin'!
 				if e := dec.DecodeElement(out, &se); e != nil {

--- a/decode.go
+++ b/decode.go
@@ -72,13 +72,13 @@ type Domain struct {
 }
 
 type domainCheckResults struct {
-	Results	[]DomainCheckResult `xml:"item"`
+	Results []DomainCheckResult `xml:"item"`
 }
 
 type DomainCheckResult struct {
-	DomainName	string		`xml:"domainName"`
-	Status		string		`xml:"status"`
-	Actions		[]string	`xml:"actions>item"`
+	DomainName string   `xml:"domainName"`
+	Status     string   `xml:"status"`
+	Actions    []string `xml:"actions>item"`
 }
 
 // Convert rawbody to XML and subtract the 'body' from the

--- a/decode.go
+++ b/decode.go
@@ -71,6 +71,16 @@ type Domain struct {
 	RenewalDate      string `xml:"renewalDate"`
 }
 
+type domainCheckResults struct {
+	Results	[]DomainCheckResult `xml:"item"`
+}
+
+type DomainCheckResult struct {
+	DomainName	string		`xml:"domainName"`
+	Status		string		`xml:"status"`
+	Actions		[]string	`xml:"actions>item"`
+}
+
 // Convert rawbody to XML and subtract the 'body' from the
 // SOAP-envelope into the struct given with out
 func decode(rawbody []byte, out interface{}) error {

--- a/decode.go
+++ b/decode.go
@@ -24,7 +24,7 @@ type DomainNames struct {
 }
 
 type Domains struct {
-    Domains []Domain `xml:"item"`
+	Domains []Domain `xml:"item"`
 }
 
 type DomainNameserver struct {

--- a/decode.go
+++ b/decode.go
@@ -19,7 +19,7 @@ type SOAPFault struct {
 	Detail string `xml:"detail,omitempty"`
 }
 
-type DomainNames struct {
+type domainNames struct {
 	Item []string `xml:"item"`
 }
 

--- a/decode.go
+++ b/decode.go
@@ -1,7 +1,7 @@
 // Package soap implements SOAP-logic for the TransIP API.
 // decode.go contains the logic to convert the XML to the corresponding
 // datastructures
-package soap
+package transip
 
 import (
 	"bytes"

--- a/decode.go
+++ b/decode.go
@@ -69,7 +69,7 @@ type Domain struct {
 
 // Convert rawbody to XML and subtract the 'body' from the
 // SOAP-envelope into the struct given with out
-func Decode(rawbody []byte, out interface{}) error {
+func decode(rawbody []byte, out interface{}) error {
 	dec := xml.NewDecoder(bytes.NewReader(rawbody))
 
 	for {

--- a/domainservice.go
+++ b/domainservice.go
@@ -45,7 +45,7 @@ func (c *DomainService) Domain(name string) (*soap.Domain, error) {
 	return domain, e
 }
 
-func (c *DomainService) Domains(names []string) (*soap.Domains, error) {
+func (c *DomainService) Domains(names []string) ([]soap.Domain, error) {
 	entryTemplate := `<item xsi:type="xsd:string">%s</item>`
 	params := []signature.KV{}
 	xml := ``
@@ -69,7 +69,7 @@ func (c *DomainService) Domains(names []string) (*soap.Domains, error) {
 
 	domains := &soap.Domains{}
 	e = soap.Decode(rawbody, &domains)
-	return domains, e
+	return domains.Domains, e
 }
 
 func (c *DomainService) SetDNSEntries(domain string, entries []soap.DomainDNSentry) error {

--- a/domainservice.go
+++ b/domainservice.go
@@ -16,13 +16,13 @@ type DomainService struct {
 	Creds creds.Client
 }
 
-func (c *DomainService) DomainNames() (*soap.Domains, error) {
+func (c *DomainService) DomainNames() (*soap.DomainNames, error) {
 	rawbody, e := soap.Lookup(c.Creds, soap.Request{Service: domainService, Method: "getDomainNames", Body: `<ns1:getDomainNames/>`})
 	if e != nil {
 		return nil, e
 	}
 
-	domains := &soap.Domains{}
+	domains := &soap.DomainNames{}
 	e = soap.Decode(rawbody, &domains)
 	return domains, e
 }
@@ -43,6 +43,33 @@ func (c *DomainService) Domain(name string) (*soap.Domain, error) {
 	domain := &soap.Domain{}
 	e = soap.Decode(rawbody, &domain)
 	return domain, e
+}
+
+func (c *DomainService) Domains(names []string) (*soap.Domains, error) {
+    entryTemplate := `<item xsi:type="xsd:string">%s</item>`
+    params := []signature.KV{}
+    xml := ``
+
+    for idx, v := range names {
+        xml = xml + fmt.Sprintf(entryTemplate, v)
+        params = append(params, []signature.KV{
+            {Key: fmt.Sprintf("0[%d]", idx), Value: v},
+        }...)
+    }
+
+	rawbody, e := soap.Lookup(c.Creds, soap.Request{
+		Service: domainService,
+		ExtraParams: params,
+		Method: "batchGetInfo",
+        Body:   fmt.Sprintf(`<ns1:batchGetInfo><domainNames SOAP-ENC:arrayType="xsd:string[%d]" xsi:type="ns1:ArrayOfString">%s</domainNames></ns1:batchGetInfo>`, len(names), xml),
+	})
+	if e != nil {
+		return nil, e
+	}
+
+	domains := &soap.Domains{}
+	e = soap.Decode(rawbody, &domains)
+	return domains, e
 }
 
 func (c *DomainService) SetDNSEntries(domain string, entries []soap.DomainDNSentry) error {

--- a/domainservice.go
+++ b/domainservice.go
@@ -14,20 +14,20 @@ type DomainService struct {
 }
 
 func (c *DomainService) DomainNames() ([]string, error) {
-	rawbody, e := Lookup(c.Creds, Request{Service: domainService, Method: "getDomainNames", Body: `<ns1:getDomainNames/>`})
+	rawbody, e := lookup(c.Creds, request{Service: domainService, Method: "getDomainNames", Body: `<ns1:getDomainNames/>`})
 	if e != nil {
 		return nil, e
 	}
 
 	domains := &DomainNames{}
-	e = Decode(rawbody, &domains)
+	e = decode(rawbody, &domains)
 	return domains.Item, e
 }
 
 func (c *DomainService) Domain(name string) (*Domain, error) {
-	rawbody, e := Lookup(c.Creds, Request{
+	rawbody, e := lookup(c.Creds, request{
 		Service: domainService,
-		ExtraParams: []KV{
+		ExtraParams: []kV{
 			{Key: "0", Value: name},
 		},
 		Method: "getInfo",
@@ -38,23 +38,23 @@ func (c *DomainService) Domain(name string) (*Domain, error) {
 	}
 
 	domain := &Domain{}
-	e = Decode(rawbody, &domain)
+	e = decode(rawbody, &domain)
 	return domain, e
 }
 
 func (c *DomainService) Domains(names []string) ([]Domain, error) {
 	entryTemplate := `<item xsi:type="xsd:string">%s</item>`
-	params := []KV{}
+	params := []kV{}
 	xml := ``
 
 	for idx, v := range names {
 		xml = xml + fmt.Sprintf(entryTemplate, v)
-		params = append(params, []KV{
+		params = append(params, []kV{
 			{Key: fmt.Sprintf("0[%d]", idx), Value: v},
 		}...)
 	}
 
-	rawbody, e := Lookup(c.Creds, Request{
+	rawbody, e := lookup(c.Creds, request{
 		Service:     domainService,
 		ExtraParams: params,
 		Method:      "batchGetInfo",
@@ -65,21 +65,21 @@ func (c *DomainService) Domains(names []string) ([]Domain, error) {
 	}
 
 	domains := &Domains{}
-	e = Decode(rawbody, &domains)
+	e = decode(rawbody, &domains)
 	return domains.Domains, e
 }
 
 func (c *DomainService) SetDNSEntries(domain string, entries []DomainDNSentry) error {
 	entryTemplate := `<item xsi:type="ns1:DnsEntry"><name xsi:type="xsd:string">%s</name><expire xsi:type="xsd:int">%d</expire><type xsi:type="xsd:string">%s</type><content xsi:type="xsd:string">%s</content></item>`
 
-	params := []KV{
+	params := []kV{
 		{Key: "0", Value: domain},
 	}
 	xml := ``
 
 	for idx, entry := range entries {
 		xml = xml + fmt.Sprintf(entryTemplate, entry.Name, entry.Expire, entry.Type, entry.Content)
-		params = append(params, []KV{
+		params = append(params, []kV{
 			{fmt.Sprintf("1[%d][name]", idx), entry.Name},
 			{fmt.Sprintf("1[%d][expire]", idx), strconv.Itoa(entry.Expire)},
 			{fmt.Sprintf("1[%d][type]", idx), entry.Type},
@@ -87,7 +87,7 @@ func (c *DomainService) SetDNSEntries(domain string, entries []DomainDNSentry) e
 		}...)
 	}
 
-	rawbody, e := Lookup(c.Creds, Request{
+	rawbody, e := lookup(c.Creds, request{
 		Service:     domainService,
 		ExtraParams: params,
 		Method:      "setDnsEntries",

--- a/domainservice.go
+++ b/domainservice.go
@@ -105,3 +105,21 @@ func (c *DomainService) SetDNSEntries(domain string, entries []DomainDNSentry) e
 	}
 	return nil
 }
+
+func (c *DomainService) CheckAvailability(name string) (string, error) {
+	rawbody, e := lookup(c.Creds, request{
+		Service: domainService,
+		ExtraParams: []kV{
+			{Key: "0", Value: name},
+		},
+		Method: "checkAvailability",
+		Body:   fmt.Sprintf(`<ns1:checkAvailability><domainName xsi:type="xsd:string">%s</domainName></ns1:checkAvailability>`, name),
+	})
+	if e != nil {
+		return "", e
+	}
+
+	availability := &availability{}
+	e = decode(rawbody, &availability)
+	return availability.Item, e
+}

--- a/domainservice.go
+++ b/domainservice.go
@@ -19,7 +19,7 @@ func (c *DomainService) DomainNames() ([]string, error) {
 		return nil, e
 	}
 
-	domains := &DomainNames{}
+	domains := &domainNames{}
 	e = decode(rawbody, &domains)
 	return domains.Item, e
 }

--- a/domainservice.go
+++ b/domainservice.go
@@ -13,7 +13,7 @@ type DomainService struct {
 	Creds Client
 }
 
-func (c *DomainService) DomainNames() (*DomainNames, error) {
+func (c *DomainService) DomainNames() ([]string, error) {
 	rawbody, e := Lookup(c.Creds, Request{Service: domainService, Method: "getDomainNames", Body: `<ns1:getDomainNames/>`})
 	if e != nil {
 		return nil, e
@@ -21,7 +21,7 @@ func (c *DomainService) DomainNames() (*DomainNames, error) {
 
 	domains := &DomainNames{}
 	e = Decode(rawbody, &domains)
-	return domains, e
+	return domains.Item, e
 }
 
 func (c *DomainService) Domain(name string) (*Domain, error) {

--- a/domainservice.go
+++ b/domainservice.go
@@ -4,33 +4,30 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/mpdroog/transip/creds"
-	"github.com/mpdroog/transip/soap"
-	"github.com/mpdroog/transip/soap/signature"
 	"strconv"
 )
 
 const domainService = "DomainService"
 
 type DomainService struct {
-	Creds creds.Client
+	Creds Client
 }
 
-func (c *DomainService) DomainNames() (*soap.DomainNames, error) {
-	rawbody, e := soap.Lookup(c.Creds, soap.Request{Service: domainService, Method: "getDomainNames", Body: `<ns1:getDomainNames/>`})
+func (c *DomainService) DomainNames() (*DomainNames, error) {
+	rawbody, e := Lookup(c.Creds, Request{Service: domainService, Method: "getDomainNames", Body: `<ns1:getDomainNames/>`})
 	if e != nil {
 		return nil, e
 	}
 
-	domains := &soap.DomainNames{}
-	e = soap.Decode(rawbody, &domains)
+	domains := &DomainNames{}
+	e = Decode(rawbody, &domains)
 	return domains, e
 }
 
-func (c *DomainService) Domain(name string) (*soap.Domain, error) {
-	rawbody, e := soap.Lookup(c.Creds, soap.Request{
+func (c *DomainService) Domain(name string) (*Domain, error) {
+	rawbody, e := Lookup(c.Creds, Request{
 		Service: domainService,
-		ExtraParams: []signature.KV{
+		ExtraParams: []KV{
 			{Key: "0", Value: name},
 		},
 		Method: "getInfo",
@@ -40,24 +37,24 @@ func (c *DomainService) Domain(name string) (*soap.Domain, error) {
 		return nil, e
 	}
 
-	domain := &soap.Domain{}
-	e = soap.Decode(rawbody, &domain)
+	domain := &Domain{}
+	e = Decode(rawbody, &domain)
 	return domain, e
 }
 
-func (c *DomainService) Domains(names []string) ([]soap.Domain, error) {
+func (c *DomainService) Domains(names []string) ([]Domain, error) {
 	entryTemplate := `<item xsi:type="xsd:string">%s</item>`
-	params := []signature.KV{}
+	params := []KV{}
 	xml := ``
 
 	for idx, v := range names {
 		xml = xml + fmt.Sprintf(entryTemplate, v)
-		params = append(params, []signature.KV{
+		params = append(params, []KV{
 			{Key: fmt.Sprintf("0[%d]", idx), Value: v},
 		}...)
 	}
 
-	rawbody, e := soap.Lookup(c.Creds, soap.Request{
+	rawbody, e := Lookup(c.Creds, Request{
 		Service:     domainService,
 		ExtraParams: params,
 		Method:      "batchGetInfo",
@@ -67,22 +64,22 @@ func (c *DomainService) Domains(names []string) ([]soap.Domain, error) {
 		return nil, e
 	}
 
-	domains := &soap.Domains{}
-	e = soap.Decode(rawbody, &domains)
+	domains := &Domains{}
+	e = Decode(rawbody, &domains)
 	return domains.Domains, e
 }
 
-func (c *DomainService) SetDNSEntries(domain string, entries []soap.DomainDNSentry) error {
+func (c *DomainService) SetDNSEntries(domain string, entries []DomainDNSentry) error {
 	entryTemplate := `<item xsi:type="ns1:DnsEntry"><name xsi:type="xsd:string">%s</name><expire xsi:type="xsd:int">%d</expire><type xsi:type="xsd:string">%s</type><content xsi:type="xsd:string">%s</content></item>`
 
-	params := []signature.KV{
+	params := []KV{
 		{Key: "0", Value: domain},
 	}
 	xml := ``
 
 	for idx, entry := range entries {
 		xml = xml + fmt.Sprintf(entryTemplate, entry.Name, entry.Expire, entry.Type, entry.Content)
-		params = append(params, []signature.KV{
+		params = append(params, []KV{
 			{fmt.Sprintf("1[%d][name]", idx), entry.Name},
 			{fmt.Sprintf("1[%d][expire]", idx), strconv.Itoa(entry.Expire)},
 			{fmt.Sprintf("1[%d][type]", idx), entry.Type},
@@ -90,7 +87,7 @@ func (c *DomainService) SetDNSEntries(domain string, entries []soap.DomainDNSent
 		}...)
 	}
 
-	rawbody, e := soap.Lookup(c.Creds, soap.Request{
+	rawbody, e := Lookup(c.Creds, Request{
 		Service:     domainService,
 		ExtraParams: params,
 		Method:      "setDnsEntries",

--- a/domainservice.go
+++ b/domainservice.go
@@ -46,22 +46,22 @@ func (c *DomainService) Domain(name string) (*soap.Domain, error) {
 }
 
 func (c *DomainService) Domains(names []string) (*soap.Domains, error) {
-    entryTemplate := `<item xsi:type="xsd:string">%s</item>`
-    params := []signature.KV{}
-    xml := ``
+	entryTemplate := `<item xsi:type="xsd:string">%s</item>`
+	params := []signature.KV{}
+	xml := ``
 
-    for idx, v := range names {
-        xml = xml + fmt.Sprintf(entryTemplate, v)
-        params = append(params, []signature.KV{
-            {Key: fmt.Sprintf("0[%d]", idx), Value: v},
-        }...)
-    }
+	for idx, v := range names {
+		xml = xml + fmt.Sprintf(entryTemplate, v)
+		params = append(params, []signature.KV{
+			{Key: fmt.Sprintf("0[%d]", idx), Value: v},
+		}...)
+	}
 
 	rawbody, e := soap.Lookup(c.Creds, soap.Request{
-		Service: domainService,
+		Service:     domainService,
 		ExtraParams: params,
-		Method: "batchGetInfo",
-        Body:   fmt.Sprintf(`<ns1:batchGetInfo><domainNames SOAP-ENC:arrayType="xsd:string[%d]" xsi:type="ns1:ArrayOfString">%s</domainNames></ns1:batchGetInfo>`, len(names), xml),
+		Method:      "batchGetInfo",
+		Body:        fmt.Sprintf(`<ns1:batchGetInfo><domainNames SOAP-ENC:arrayType="xsd:string[%d]" xsi:type="ns1:ArrayOfString">%s</domainNames></ns1:batchGetInfo>`, len(names), xml),
 	})
 	if e != nil {
 		return nil, e

--- a/signature.go
+++ b/signature.go
@@ -1,6 +1,6 @@
 // Package signature creates a cookie signature to validate
 // a request for the TransIP API
-package signature
+package transip
 
 import (
 	"crypto"

--- a/signature.go
+++ b/signature.go
@@ -28,7 +28,7 @@ func sha512ASN1(data []byte) []byte {
 	return append(asn1, h.Sum(nil)...)
 }
 
-func Sign(privKey *rsa.PrivateKey, params []KV) (string, error) {
+func sign(privKey *rsa.PrivateKey, params []kV) (string, error) {
 	asn1 := sha512ASN1(urlencode(params))
 
 	sig, e := rsa.SignPKCS1v15(nil, privKey, crypto.Hash(0), asn1)

--- a/signature_test.go
+++ b/signature_test.go
@@ -1,4 +1,4 @@
-package signature
+package transip
 
 import (
 	"bytes"

--- a/signature_test.go
+++ b/signature_test.go
@@ -3,10 +3,10 @@ package transip
 import (
 	"bytes"
 	"crypto/rsa"
-	"encoding/base64"
-	"testing"
-	"encoding/pem"
 	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"testing"
 )
 
 func TestParamEncode(t *testing.T) {
@@ -69,12 +69,12 @@ func TestBase64(t *testing.T) {
 func TestSign(t *testing.T) {
 	expect := `3xhFhDsp1H2%2Ba4LidS2hXuQQjNmsxIGlEkgastg9jO5BRvqTLUXppAXjhieoq4P%2Bf8E5BF9%2FZ4SnYWKkQUvMbG%2BfoMnmK%2BGL6CwYeyn%2FLglZMNrFdoMw18PRH1iW3quvF2yxVcnCJXT%2FRwXUQu4TbH7f8kYH12R20hNI6HlDDx%2FQbLPtMyS9nMAmhhebtmjnutlmZS%2BCK%2Bh9jllaGcMiCorYGBD5aXHu%2FUdlsxmzSQ8acvtDa%2BfBkZ%2BDcvi%2B9fafzMCxd1OT5%2BP9vj93u1i9VmL0Bz3Z88Uj%2FxCnTXH0VdZZGyWuqKNNjawXs1wwoJ5%2FrDhMCyVdqt%2Fb8X2%2Bt%2F%2Bpww%3D%3D`
 	sig, e := Sign(privKey(), []KV{
-			{"__method", "getDomainNames"},
-			{"__service", "DomainService"},
-			{"__hostname", "api.transip.nl"},
-			{"__timestamp", "1492851509"},
-			{"__nonce", "58fb1b35916f25.33598874"},
-		})
+		{"__method", "getDomainNames"},
+		{"__service", "DomainService"},
+		{"__hostname", "api.transip.nl"},
+		{"__timestamp", "1492851509"},
+		{"__nonce", "58fb1b35916f25.33598874"},
+	})
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -113,6 +113,6 @@ u7Isy/Q8xjHsJG6KP2/pMvMG42lhB3b+GKSmxVM999U30SdgorE3Kw==
 -----END RSA PRIVATE KEY-----`)
 
 	block, _ := pem.Decode(keyContents)
-	privKey,_ := x509.ParsePKCS1PrivateKey(block.Bytes)
+	privKey, _ := x509.ParsePKCS1PrivateKey(block.Bytes)
 	return privKey
 }

--- a/signature_test.go
+++ b/signature_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func TestParamEncode(t *testing.T) {
-	in := []KV{
-		KV{"__method", "getDomainNames"},
-		KV{"__service", "DomainService"},
-		KV{"__hostname", "api.transip.nl"},
-		KV{"__timestamp", "1492760973"},
-		KV{"__nonce", "58f9b98ddd3999.86051758"},
+	in := []kV{
+		kV{"__method", "getDomainNames"},
+		kV{"__service", "DomainService"},
+		kV{"__hostname", "api.transip.nl"},
+		kV{"__timestamp", "1492760973"},
+		kV{"__nonce", "58f9b98ddd3999.86051758"},
 	}
 	expect := []byte(`__method=getDomainNames&__service=DomainService&__hostname=api.transip.nl&__timestamp=1492760973&__nonce=58f9b98ddd3999.86051758`)
 

--- a/soap.go
+++ b/soap.go
@@ -4,13 +4,13 @@ package transip
 import (
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
-	"fmt"
-	"strconv"
 )
 
 const API_URL = "api.transip.nl"
@@ -29,10 +29,10 @@ func uniqid() string {
 }
 
 type request struct {
-	Service     string         // Service to call on TransIP side
-	ExtraParams []kV // Additional params for the signature-code
-	Body        string         // XML body to send in envelope
-	Method      string         // Method to call on service
+	Service     string // Service to call on TransIP side
+	ExtraParams []kV   // Additional params for the signature-code
+	Body        string // XML body to send in envelope
+	Method      string // Method to call on service
 }
 
 func lookup(c Client, in request) ([]byte, error) {

--- a/soap.go
+++ b/soap.go
@@ -28,14 +28,14 @@ func uniqid() string {
 	)
 }
 
-type Request struct {
+type request struct {
 	Service     string         // Service to call on TransIP side
-	ExtraParams []KV // Additional params for the signature-code
+	ExtraParams []kV // Additional params for the signature-code
 	Body        string         // XML body to send in envelope
 	Method      string         // Method to call on service
 }
 
-func Lookup(c Client, in Request) ([]byte, error) {
+func lookup(c Client, in request) ([]byte, error) {
 	raw := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
 	xmlns:ns1="%s" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -83,14 +83,14 @@ func Lookup(c Client, in Request) ([]byte, error) {
 	})
 
 	kv := in.ExtraParams
-	kv = append(kv, []KV{
+	kv = append(kv, []kV{
 		{"__method", in.Method},
 		{"__service", in.Service},
 		{"__hostname", API_URL},
 		{"__timestamp", now},
 		{"__nonce", nonce}}...,
 	)
-	sig, e := Sign(c.PrivateKey, kv)
+	sig, e := sign(c.PrivateKey, kv)
 	if e != nil {
 		return []byte{}, e
 	}

--- a/soap.go
+++ b/soap.go
@@ -1,5 +1,5 @@
 // Package soap implements SOAP-logic for the TransIP API.
-package soap
+package transip
 
 import (
 	"crypto/tls"
@@ -9,10 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
-
 	"fmt"
-	"github.com/mpdroog/transip/creds"
-	"github.com/mpdroog/transip/soap/signature"
 	"strconv"
 )
 
@@ -33,12 +30,12 @@ func uniqid() string {
 
 type Request struct {
 	Service     string         // Service to call on TransIP side
-	ExtraParams []signature.KV // Additional params for the signature-code
+	ExtraParams []KV // Additional params for the signature-code
 	Body        string         // XML body to send in envelope
 	Method      string         // Method to call on service
 }
 
-func Lookup(c creds.Client, in Request) ([]byte, error) {
+func Lookup(c Client, in Request) ([]byte, error) {
 	raw := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
 	xmlns:ns1="%s" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -86,14 +83,14 @@ func Lookup(c creds.Client, in Request) ([]byte, error) {
 	})
 
 	kv := in.ExtraParams
-	kv = append(kv, []signature.KV{
+	kv = append(kv, []KV{
 		{"__method", in.Method},
 		{"__service", in.Service},
 		{"__hostname", API_URL},
 		{"__timestamp", now},
 		{"__nonce", nonce}}...,
 	)
-	sig, e := signature.Sign(c.PrivateKey, kv)
+	sig, e := Sign(c.PrivateKey, kv)
 	if e != nil {
 		return []byte{}, e
 	}

--- a/soap/decode.go
+++ b/soap/decode.go
@@ -19,8 +19,12 @@ type SOAPFault struct {
 	Detail string `xml:"detail,omitempty"`
 }
 
-type Domains struct {
+type DomainNames struct {
 	Item []string `xml:"item"`
+}
+
+type Domains struct {
+    Domains []Domain `xml:"item"`
 }
 
 type DomainNameserver struct {

--- a/urlencode.go
+++ b/urlencode.go
@@ -1,4 +1,4 @@
-package signature
+package transip
 
 import (
 	"bytes"

--- a/urlencode.go
+++ b/urlencode.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-type KV struct {
+type kV struct {
 	Key   string
 	Value string
 }
@@ -14,7 +14,7 @@ type KV struct {
 // Encode encodes the values into ``URL encoded'' form
 // ("bar=baz&foo=quux") NOT sorted.
 // https://golang.org/src/net/url/url.go?s=24497:24528#L850
-func urlencode(v []KV) []byte {
+func urlencode(v []kV) []byte {
 	if v == nil {
 		return []byte{}
 	}


### PR DESCRIPTION
By removing the soap, and creds packages and folding everything into the transip package users of the library get a much cleaner interface to work with. Functions return `transip.Domain` or `[]transip.Domain` or you can work with `transip.DomainDNSEntries`. The `DomainService.DomainNames()` function even returns a []string instead of `soap.Domains` where `soap.Domains.Item` is the slice a user cares about.

I have also reduced the numer of exported functions and structs. The soap encode en decode functions are only used internally by the library.